### PR TITLE
fix: incorrect progress bar on mobile

### DIFF
--- a/components/shared/PredictionBar.tsx
+++ b/components/shared/PredictionBar.tsx
@@ -5,7 +5,7 @@ import { AnswerType } from 'types';
 import { useAgentsBets } from 'hooks/useAgentsBets';
 import { convertToPercentage } from 'utils/questions';
 
-import { LeftLine, ProgressBarContainer, RightLine } from './styles';
+import { LeftLine, OutcomesValues, ProgressBarContainer, RightLine } from './styles';
 
 const { Text } = Typography;
 
@@ -39,16 +39,17 @@ const ProgressBar = ({
 
   return (
     <ProgressBarContainer>
-      <RightLine type={type}>
-        <LeftLine width={leftPercentage} type={type}>
-          <span>
-            {outcomes?.[0] || ''} {hasOutcomePercentages ? leftPercentage : 'NA'}%
-          </span>
-        </LeftLine>
+      <RightLine>
+        <LeftLine width={leftPercentage} type={type} />
+      </RightLine>
+      <OutcomesValues type={type}>
+        <span>
+          {outcomes?.[0] || ''} {hasOutcomePercentages ? leftPercentage : 'NA'}%
+        </span>
         <span>
           {outcomes?.[1] || ''} {hasOutcomePercentages ? rightPercentage : 'NA'}%
         </span>
-      </RightLine>
+      </OutcomesValues>
     </ProgressBarContainer>
   );
 };

--- a/components/shared/styles.tsx
+++ b/components/shared/styles.tsx
@@ -114,7 +114,6 @@ export const LeftLine = styled.div<{ width: number; type: AnswerType }>`
       ? 'linear-gradient(180deg, #884DFF 0%, #6A38FF 100%)'
       : 'linear-gradient(180deg, #ffffff 0%, #bfbfbf 100%)'};
   height: 24px;
-  padding: 0px 156px 0px 0px;
   border-radius: 2px;
   position: absolute;
   left: 0;
@@ -123,29 +122,25 @@ export const LeftLine = styled.div<{ width: number; type: AnswerType }>`
   align-items: center;
   gap: 4px;
   z-index: 1;
-
-  > span {
-    font-weight: 500;
-    position: absolute;
-    top: 2px;
-    left: 8px;
-    color: white;
-    mix-blend-mode: ${({ type }) => (type === 'ongoing' ? 'normal' : 'difference')};
-  }
 `;
 
-export const RightLine = styled.div<{ type: AnswerType }>`
+export const RightLine = styled.div`
   background: rgba(0, 0, 0, 0.3);
   flex-grow: 1;
   height: 24px;
   border-radius: 2px;
   position: relative;
+`;
 
+export const OutcomesValues = styled.div<{ type: AnswerType }>`
+  display: flex;
+  justify-content: space-between;
+  position: absolute;
+  top: 2px;
+  left: 8px;
+  right: 8px;
   > span {
     font-weight: 500;
-    position: absolute;
-    top: 2px;
-    right: 8px;
     z-index: 1;
     mix-blend-mode: ${({ type }) => (type === 'ongoing' ? 'normal' : 'difference')};
   }


### PR DESCRIPTION
## Fixes

There’s an issue with the incorrect line width on mobile screens when the left part is longer than the corresponding percentage value

<img width="453" alt="image" src="https://github.com/user-attachments/assets/d3030624-b1f2-4836-8ea2-3b6a5a19ac45">


the fix (displays both states for clarity, the bottom line is for closed markets where the colors are different)
![image](https://github.com/user-attachments/assets/d56b4804-4317-4d05-ab26-4a7908a4f9f0)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
